### PR TITLE
Fix/max openfiles limit

### DIFF
--- a/conf/nutcracker.yml
+++ b/conf/nutcracker.yml
@@ -1,5 +1,6 @@
 global:
   worker_processes: 4         # num of workers, fallback to single process model while worker_processes is 0
+  max_openfiles: 102400       # max num of open files in every worker process
   user: nobody                # user of worker's process, master process should be setup with root
   group: nobody               # group of worker's process
   worker_shutdown_timeout: 30 # terminate the old worker after worker_shutdown_timeout, unit is second

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -128,6 +128,12 @@ static struct command conf_global_commands[] = {
     },
 
     {
+        string("max_openfiles"),
+        conf_set_num,
+        offsetof(struct conf_global, max_openfiles)
+    },
+
+    {
         string("worker_shutdown_timeout"),
         conf_set_num,
         offsetof(struct conf_global, worker_shutdown_timeout)
@@ -831,6 +837,7 @@ conf_parse_global_section(struct conf *cf)
 
     // init global conf
     cf->global.worker_processes = CONF_UNSET_NUM;
+    cf->global.max_openfiles = CONF_UNSET_NUM;
     cf->global.worker_shutdown_timeout = CONF_UNSET_NUM;
     string_init(&cf->global.user);
     string_init(&cf->global.group);
@@ -911,6 +918,9 @@ conf_parse(struct conf *cf)
 
     if (cf->global.worker_shutdown_timeout == CONF_UNSET_NUM) {
         cf->global.worker_shutdown_timeout = CONF_DEFAULT_WORKER_SHUTDOWN_TIMEOUT;
+    }
+    if (cf->global.max_openfiles == CONF_UNSET_NUM) {
+        cf->global.max_openfiles= CONF_DEFAULT_MAX_OPENFILES;
     }
 
     // get uid

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -57,6 +57,7 @@
 #define CONF_DEFAULT_KETAMA_PORT             11211
 #define CONF_DEFAULT_TCPKEEPALIVE            false
 #define CONF_DEFAULT_WORKER_SHUTDOWN_TIMEOUT 30
+#define CONF_DEFAULT_MAX_OPENFILES           102400
 #define CONF_DEFAULT_USER                    "nobody"
 #define CONF_DEFAULT_GROUP                   "nobody"
 
@@ -105,6 +106,7 @@ struct conf_pool {
 struct conf_global {
     int           worker_processes; // number of worker processes
     int           worker_shutdown_timeout; // number of seconds that worker would be quit after signal terminate was received
+    int           max_openfiles; // max number of open files
     struct string user;
     struct string group;
     uid_t         uid;

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -52,7 +52,7 @@ core_calc_connections(struct context *ctx)
     int status;
     struct rlimit limit;
 
-    adjust_openfiles_limit(102400);
+    adjust_openfiles_limit((rlim_t)ctx->cf->global.max_openfiles);
     status = getrlimit(RLIMIT_NOFILE, &limit);
     if (status < 0) {
         log_error("getrlimit failed: %s", strerror(errno));

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -25,12 +25,34 @@
 
 static uint32_t ctx_id; /* context generation */
 
+static void
+adjust_openfiles_limit(rlim_t maxfiles) {
+    // Note: we just improve the open files to a higher num,
+    // while the twemproxy didn't support max client connections now.
+    struct rlimit limit;
+    rlim_t old_limit, best_limit = maxfiles, decr_step = 16;
+    if (getrlimit(RLIMIT_NOFILE, &limit) < 0 || best_limit <= limit.rlim_cur) {
+        return;
+    }
+    old_limit = limit.rlim_cur;
+    while(best_limit > old_limit) {
+        limit.rlim_cur = best_limit;
+        limit.rlim_max = best_limit;
+        if (setrlimit(RLIMIT_NOFILE,&limit) != -1) break;
+        /* We failed to set file limit to 'bestlimit'. Try with a
+         * smaller limit decrementing by a few FDs per iteration. */
+        if (best_limit < decr_step) break;
+        best_limit -= decr_step;
+    }
+}
+
 static rstatus_t
 core_calc_connections(struct context *ctx)
 {
     int status;
     struct rlimit limit;
 
+    adjust_openfiles_limit(102400);
     status = getrlimit(RLIMIT_NOFILE, &limit);
     if (status < 0) {
         log_error("getrlimit failed: %s", strerror(errno));
@@ -39,7 +61,7 @@ core_calc_connections(struct context *ctx)
 
     ctx->max_nfd = (uint32_t)limit.rlim_cur;
     ctx->max_ncconn = ctx->max_nfd - ctx->max_nsconn - RESERVED_FDS;
-    log_debug(LOG_NOTICE, "max fds %"PRIu32" max client conns %"PRIu32" "
+    log_warn("max fds %"PRIu32" max client conns %"PRIu32" "
               "max server conns %"PRIu32"", ctx->max_nfd, ctx->max_ncconn,
               ctx->max_nsconn);
 

--- a/src/nc_proxy.c
+++ b/src/nc_proxy.c
@@ -381,7 +381,7 @@ proxy_accept(struct context *ctx, struct conn *p)
     }
 
     if (conn_ncurr_cconn() >= ctx->max_ncconn) {
-        log_debug(LOG_CRIT, "client connections %"PRIu32" exceed limit %"PRIu32,
+        log_warn("client connections %"PRIu32" exceed limit %"PRIu32,
                   conn_ncurr_cconn(), ctx->max_ncconn);
         status = close(sd);
         if (status < 0) {


### PR DESCRIPTION
the default openfiles limit in os was too smaller, e.g. the centos was 1024. 