### PR TITLE
FIX: unix socket can't shrink the workers

### DIFF
--- a/src/nc.c
+++ b/src/nc.c
@@ -623,6 +623,7 @@ main(int argc, char **argv)
     rstatus_t status;
     struct instance nci;
 
+    nci.id = -1;
     nci.role = ROLE_MASTER;
     nci.chan = NULL;
     nci.workers.nelem = 0;

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -77,7 +77,7 @@ core_ctx_create(struct instance *nci) {
     if (ctx == NULL) {
         return NULL;
     }
-    ctx->id = ++ctx_id;
+    ctx->id = nci->id;
     ctx->cf = NULL;
     ctx->stats = NULL;
     ctx->evb = NULL;

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -125,7 +125,7 @@ struct event_base;
 #include <nc_channel.h>
 
 struct context {
-    uint32_t           id;          /* unique context id */
+    int                id;          /* unique context id */
     struct conf        *cf;         /* configuration */
     struct stats       *stats;      /* stats */
 
@@ -143,6 +143,7 @@ struct context {
 
 
 struct instance {
+    int              id;                           /* store the worker id, master should -1 */
     struct context   *ctx;                        /* active context */
     int              log_level;                   /* log level */
     char             *log_filename;               /* log filename */

--- a/src/nc_process.c
+++ b/src/nc_process.c
@@ -110,6 +110,8 @@ nc_multi_processes_cycle(struct instance *parent_nci)
             if (status != NC_OK) {
                 // skip reloading
                 parent_nci->ctx = prev_ctx;
+                ctx->stats = NULL;
+                core_ctx_destroy(ctx);
                 continue;
             }
             prev_ctx->stats = NULL;

--- a/src/nc_process.c
+++ b/src/nc_process.c
@@ -25,13 +25,14 @@ bool pm_terminate= false; // quit after worker_shutdown_timeout
 struct instance *master_nci = NULL;
 
 static rstatus_t
-nc_clone_instance(struct instance *dst, struct instance *src)
+nc_clone_instance(int worker_id, struct instance *dst, struct instance *src)
 {
     struct context *new_ctx;
     if (dst == NULL || src == NULL) {
         return NC_ERROR;
     }
     nc_memcpy(dst, src, sizeof(struct instance));
+    dst->id = worker_id;
     new_ctx = core_ctx_create(dst);
     if (new_ctx == NULL) {
         log_error("failed to create context");
@@ -156,7 +157,7 @@ nc_setup_listener_for_workers(struct instance *parent_nci, bool reloading)
 
     for (i = 0; i < n; i++) {
         worker_nci = array_push(&parent_nci->workers);
-        status = nc_clone_instance(worker_nci, parent_nci);
+        status = nc_clone_instance(i, worker_nci, parent_nci);
         if (status != NC_OK) {
             log_error("failed to clone parent_nci, rollback");
             goto rollback_step2;


### PR DESCRIPTION
问题:
UNIX socket 是通过 unlink 来实现 reuse, 所以实际上只有最后一个 worker 能够 bind 成功，这个在缩减 worker 的时候，最后一个真正监听的 worker 因为没有对应的新 worker 来承接导致退出。

解决:
任何时候都只有第一个 worker 来 listen