### PR TITLE
FIX: random ketama result when server name too long

### DIFF
--- a/src/hashkit/nc_ketama.c
+++ b/src/hashkit/nc_ketama.c
@@ -25,7 +25,7 @@
 
 #define KETAMA_CONTINUUM_ADDITION   10  /* # extra slots to build into continuum */
 #define KETAMA_POINTS_PER_SERVER    160 /* 40 points per hash */
-#define KETAMA_MAX_HOSTLEN          86
+#define KETAMA_MAX_HOSTLEN          273 /* 273 is 255(domain or ip)+1(:)+5(port)+1(-)+10(uint32)+1(\0) */
 
 static uint32_t
 ketama_hash(const char *key, size_t key_length, uint32_t alignment)
@@ -178,6 +178,9 @@ ketama_update(struct server_pool *pool)
             hostlen = snprintf(host, KETAMA_MAX_HOSTLEN, "%.*s-%u",
                                server->name.len, server->name.data,
                                pointer_index - 1);
+            if (hostlen > KETAMA_MAX_HOSTLEN) {
+                hostlen = KETAMA_MAX_HOSTLEN;
+            }
 
             for (x = 0; x < pointer_per_hash; x++) {
                 value = ketama_hash(host, hostlen, x);


### PR DESCRIPTION
When we use domain to describe a redis server in twemproxy, server name maybe too long and exceed the KETAMA_MAX_HOSTLEN=86. 

host is consist of redis/memcached addr, port and continuum pointer_index.
```
hostlen = snprintf(host, KETAMA_MAX_HOSTLEN, "%.*s-%u",
                               server->name.len, server->name.data,
                               pointer_index - 1);
```

An addr may be a ip addr or domain name. According to the [RFC1035](https://tools.ietf.org/html/rfc1035), domain name length is 255 or less. So the KETAMA_MAX_HOSTLEN should be 
```
255(domain length)+1(:)+5(port max length)+1(-)+10(pointer_index max length)+1(\0)=273
```

The return value of snprintf maybe exceed KETAMA_MAX_HOSTLEN. 

>The snprintf() and vsnprintf() functions will write at most size-1 of the characters printed into the output string (the size'th character then gets the terminating `\0'); if the return value is greater than or equal to the size argument, the string was too short and some of the printed characters were dis-carded.  The output is always null-terminated, unless size is 0.

Use the return value of snprintf to do md5_signature could memcpy random data. So the ketama result is not stable.

```
void
MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
{
    MD5_u32plus saved_lo;
    unsigned long used, free;

    saved_lo = ctx->lo;
    if ((ctx->lo = (saved_lo + size) & 0x1fffffff) < saved_lo) {
        ctx->hi++;
    }
    ctx->hi += size >> 29;

    used = saved_lo & 0x3f;

    if (used) {
        free = 64 - used;

        if (size < free) {
            memcpy(&ctx->buffer[used], data, size);
            return;
        }

        memcpy(&ctx->buffer[used], data, free);
        data = (unsigned char *)data + free;
        size -= free;
        body(ctx, ctx->buffer, 64);
    }

    if (size >= 64) {
        data = body(ctx, data, size & ~(unsigned long)0x3f);
        size &= 0x3f;
    }

    memcpy(ctx->buffer, data, size);
}

```

To fix this, I change KETAMA_MAX_HOSTLEN to 273 and check if hostlen > KETAMA_MAX_HOSTLEN.